### PR TITLE
Add camelCase dynamic finders and counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ Return an object for the first matching the name
 Category::findOne_by_name('changed name');
 ```
 
+CamelCase alternatives are also supported:
+
+```php
+Category::findOneByName('changed name');
+```
+
 Return an object for the first match from the names
 
 ```php
@@ -165,6 +171,10 @@ Return an array of objects that match the name
 
 ```php
 Category::find_by_name('changed name');
+```
+
+```php
+Category::findByName('changed name');
 ```
 
 Return an array of objects that match the names

--- a/test-src/Model/Category.php
+++ b/test-src/Model/Category.php
@@ -4,6 +4,11 @@ namespace App\Model;
 
 /**
  * @method static array find_by_name($match)
+ * @method static array findByName($match)
+ * @method static self|null findOneByName($match)
+ * @method static self|null firstByName($match)
+ * @method static self|null lastByName($match)
+ * @method static int countByName($match)
  * @property int|null $id primary key
  * @property string|null $name category name
  * @property string|null $updated_at mysql datetime string

--- a/tests/Model/CategoryTest.php
+++ b/tests/Model/CategoryTest.php
@@ -207,4 +207,42 @@ class CategoryTest extends TestCase
         $this->assertContainsOnlyInstancesOf('App\Model\Category', $categories);
         $this->assertCount(count($_names), $categories);
     }
+
+    /**
+     * @covers ::__callStatic
+     * @covers ::fetchAllWhereMatchingSingleField
+     * @covers ::fetchOneWhereMatchingSingleField
+     * @covers ::countAllWhere
+     */
+    public function testDynamicFindersCamelCase(): void
+    {
+        $_names = [
+            'Camel_' . uniqid('a_', true),
+            'Camel_' . uniqid('b_', true),
+        ];
+        foreach ($_names as $_name) {
+            $category = new App\Model\Category(array(
+                'name' => $_name
+            ));
+            $category->save();
+        }
+
+        $categories = App\Model\Category::findByName($_names);
+        $this->assertCount(count($_names), $categories);
+
+        $one = App\Model\Category::findOneByName($_names[0]);
+        $this->assertNotNull($one);
+        $this->assertEquals($_names[0], $one->name);
+
+        $first = App\Model\Category::firstByName($_names);
+        $this->assertNotNull($first);
+        $this->assertContains($first->name, $_names);
+
+        $last = App\Model\Category::lastByName($_names);
+        $this->assertNotNull($last);
+        $this->assertContains($last->name, $_names);
+
+        $count = App\Model\Category::countByName($_names);
+        $this->assertEquals(count($_names), $count);
+    }
 }


### PR DESCRIPTION
## Summary
- support camelCase dynamic finder/counter names (findByName, countByName, etc.)
- resolve field names against actual column names and snake_case
- add PHPUnit coverage and update docs/annotations

## Testing
- not run (not requested)