### PR TITLE
test: improve coverage and CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,35 +88,5 @@ jobs:
             echo "MODEL_ORM_TEST_PASS=postgres" >> "$GITHUB_ENV"
           fi
 
-      - name: Wait for database
-        run: |
-          if [ "${{ matrix.db }}" = "mysql" ]; then
-            ready=0
-            for i in {1..30}; do
-              if nc -z 127.0.0.1 3306; then
-                ready=1
-                break
-              fi
-              sleep 1
-            done
-            if [ "$ready" -ne 1 ]; then
-              echo "MySQL did not become ready in time" >&2
-              exit 1
-            fi
-          else
-            ready=0
-            for i in {1..30}; do
-              if nc -z 127.0.0.1 5432; then
-                ready=1
-                break
-              fi
-              sleep 1
-            done
-            if [ "$ready" -ne 1 ]; then
-              echo "PostgreSQL did not become ready in time" >&2
-              exit 1
-            fi
-          fi
-
       - name: Run tests
         run: vendor/bin/phpunit -c phpunit.xml.dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,28 @@ on:
   pull_request:
 
 jobs:
+  quality:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          coverage: none
+          extensions: pdo, pdo_mysql, pdo_pgsql
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Static analysis
+        run: vendor/bin/phpstan analyse -c phpstan.neon
+
+      - name: Format check
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -21,6 +43,12 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: "1"
+          MYSQL_ROOT_HOST: "%"
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
       postgres:
         image: postgres:16
         ports:
@@ -29,6 +57,11 @@ jobs:
           POSTGRES_DB: categorytest
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd="pg_isready -U postgres -d categorytest"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
 
     steps:
       - uses: actions/checkout@v4
@@ -37,16 +70,11 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          coverage: none
           extensions: pdo, pdo_mysql, pdo_pgsql
 
       - name: Install dependencies
-        run: composer install --no-interaction --no-progress
-
-      - name: Static analysis
-        run: vendor/bin/phpstan analyse -c phpstan.neon
-
-      - name: Format check
-        run: vendor/bin/php-cs-fixer fix --dry-run --diff
+        run: composer install --no-interaction --no-progress --prefer-dist
 
       - name: Configure DB env
         run: |
@@ -63,15 +91,31 @@ jobs:
       - name: Wait for database
         run: |
           if [ "${{ matrix.db }}" = "mysql" ]; then
+            ready=0
             for i in {1..30}; do
-              nc -z 127.0.0.1 3306 && break
+              if nc -z 127.0.0.1 3306; then
+                ready=1
+                break
+              fi
               sleep 1
             done
+            if [ "$ready" -ne 1 ]; then
+              echo "MySQL did not become ready in time" >&2
+              exit 1
+            fi
           else
+            ready=0
             for i in {1..30}; do
-              nc -z 127.0.0.1 5432 && break
+              if nc -z 127.0.0.1 5432; then
+                ready=1
+                break
+              fi
               sleep 1
             done
+            if [ "$ready" -ne 1 ]; then
+              echo "PostgreSQL did not become ready in time" >&2
+              exit 1
+            fi
           fi
 
       - name: Run tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,28 +2,102 @@
 
 Thanks for contributing to `model-orm-php`.
 
-## Setup
-- PHP 8.3+ with PDO and the driver you intend to test (`pdo_mysql` or `pdo_pgsql`).
-- Install dependencies: `composer install`.
-- Start local DBs (optional): `docker-compose up -d`.
+## Ground rules
 
-## Tests
-- Run: `vendor/bin/phpunit -c phpunit.xml.dist`.
-- Use env overrides to target a DB:
-  - `MODEL_ORM_TEST_DSN` (e.g., `mysql:host=127.0.0.1;port=3306` or `pgsql:host=127.0.0.1;port=5432;dbname=categorytest`)
-  - `MODEL_ORM_TEST_USER`, `MODEL_ORM_TEST_PASS`
+- Be respectful and constructive in issues, pull requests, and review discussion.
+- Keep changes focused. Small, well-scoped pull requests are easier to review and safer to merge.
+- Preserve backward compatibility where practical, or clearly call out breaking changes.
 
-## Static Analysis
-- Run: `vendor/bin/phpstan analyse -c phpstan.neon` (use `--debug` if your environment blocks parallel workers).
+## Development setup
 
-## Formatting
-- Format: `vendor/bin/php-cs-fixer fix`.
-- Check only: `vendor/bin/php-cs-fixer fix --dry-run --diff`.
+Requirements:
 
-## Code Style
-- Keep changes minimal and consistent with existing conventions (4-space indent, `StudlyCaps` classes, `camelCase` methods).
-- Update or add tests for behavior changes.
+- PHP `8.3+`
+- `ext-pdo`
+- A PDO driver for the database you want to test against, typically `pdo_mysql` or `pdo_pgsql`
+- Composer
 
-## Pull Requests
-- Explain the change and include test results.
-- Note any DB/schema assumptions and compatibility impacts.
+Install dependencies:
+
+```bash
+composer install
+```
+
+Optional local databases:
+
+```bash
+docker-compose up -d
+```
+
+## Running checks
+
+Run the test suite:
+
+```bash
+vendor/bin/phpunit -c phpunit.xml.dist
+```
+
+Override the database connection with environment variables when needed:
+
+```bash
+MODEL_ORM_TEST_DSN=mysql:host=127.0.0.1;port=3306
+MODEL_ORM_TEST_USER=root
+MODEL_ORM_TEST_PASS=
+```
+
+Or for PostgreSQL:
+
+```bash
+MODEL_ORM_TEST_DSN=pgsql:host=127.0.0.1;port=5432;dbname=categorytest
+MODEL_ORM_TEST_USER=postgres
+MODEL_ORM_TEST_PASS=postgres
+```
+
+Run static analysis:
+
+```bash
+vendor/bin/phpstan analyse -c phpstan.neon
+```
+
+Run formatting:
+
+```bash
+vendor/bin/php-cs-fixer fix
+```
+
+Check formatting only:
+
+```bash
+vendor/bin/php-cs-fixer fix --dry-run --diff
+```
+
+## Coding expectations
+
+- Follow the existing project style: 4-space indentation, `StudlyCaps` class names, and `camelCase` methods.
+- Keep the library framework-agnostic and PDO-centered.
+- Add or update tests for behavior changes, especially around cross-database behavior.
+- Prefer clear, direct code over clever abstractions.
+
+## Pull requests
+
+Before opening a pull request:
+
+- Make sure tests pass locally for the database you changed or relied on.
+- Run PHPStan and the formatting check.
+- Update documentation when the public behavior or setup changes.
+
+When opening a pull request:
+
+- Explain the user-visible problem and the change you made.
+- Note database-specific assumptions or compatibility impacts.
+- Include the commands you ran to validate the change.
+
+## Contribution terms
+
+By submitting code, documentation, or any other contribution to this repository, you represent that:
+
+- You have the right to submit the contribution.
+- The contribution is your own original work, or you have sufficient rights to provide it under the project license.
+- You grant the project permission to use, modify, distribute, and relicense the contribution under the repository's existing license and future versions of that license as needed for project maintenance.
+
+If these terms do not work for you, do not submit the contribution until the terms are clarified with the maintainers.

--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -157,11 +157,11 @@ Category::deleteAllWhere(
 );
 ```
 
-Delete with a richer SQL fragment:
+Delete with a richer SQL fragment that works across MySQL/MariaDB and PostgreSQL:
 
 ```php
 Category::deleteAllWhere(
-    'name = ? ORDER BY name DESC LIMIT 2',
+    'id IN (SELECT id FROM categories WHERE name = ? ORDER BY name DESC LIMIT 2)',
     ['Fiction']
 );
 ```

--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -1,0 +1,218 @@
+# Examples
+
+This document shows example-led usage of `Freshsauce\Model\Model` for common application flows.
+
+## Minimal model definition
+
+Define a model by extending the base class and setting the table name:
+
+```php
+require_once 'vendor/autoload.php';
+
+Freshsauce\Model\Model::connectDb(
+    'pgsql:host=127.0.0.1;port=5432;dbname=categorytest',
+    'postgres',
+    'postgres'
+);
+
+class Category extends Freshsauce\Model\Model
+{
+    protected static $_tableName = 'categories';
+}
+```
+
+## Create a record
+
+```php
+$category = new Category([
+    'name' => 'Fiction',
+]);
+
+$category->save();
+
+echo $category->id;
+echo $category->created_at;
+echo $category->updated_at;
+```
+
+`save()` inserts when the primary key is empty and updates when the primary key is present.
+
+## Load a record by primary key
+
+```php
+$category = Category::getById(1);
+
+if ($category !== null) {
+    echo $category->name;
+}
+```
+
+## Update an existing record
+
+```php
+$category = Category::getById(1);
+
+if ($category !== null) {
+    $category->name = 'Modern Fiction';
+    $category->save();
+}
+```
+
+## Insert explicitly
+
+If you want to call the insert path directly:
+
+```php
+$category = new Category([
+    'name' => 'Biography',
+]);
+
+$category->insert();
+```
+
+## Update explicitly
+
+If you already know the object exists and want to call update directly:
+
+```php
+$category = Category::getById(1);
+
+if ($category !== null) {
+    $category->name = 'Memoir';
+    $category->update();
+}
+```
+
+## First, last, and count
+
+```php
+$first = Category::first();
+$last = Category::last();
+$count = Category::count();
+```
+
+## Dynamic finders
+
+Snake_case methods:
+
+```php
+$all = Category::find_by_name('Fiction');
+$one = Category::findOne_by_name('Fiction');
+$first = Category::first_by_name(['Fiction', 'Fantasy']);
+$last = Category::last_by_name(['Fiction', 'Fantasy']);
+$count = Category::count_by_name('Fiction');
+```
+
+CamelCase alternatives:
+
+```php
+$all = Category::findByName('Fiction');
+$one = Category::findOneByName('Fiction');
+$first = Category::firstByName(['Fiction', 'Fantasy']);
+$last = Category::lastByName(['Fiction', 'Fantasy']);
+$count = Category::countByName('Fiction');
+```
+
+## Custom WHERE clauses
+
+Fetch a single matching record:
+
+```php
+$category = Category::fetchOneWhere(
+    'id = ? OR name = ?',
+    [1, 'Fiction']
+);
+```
+
+Fetch all matching records:
+
+```php
+$categories = Category::fetchAllWhere(
+    'name IN (?, ?)',
+    ['Fiction', 'Fantasy']
+);
+```
+
+## Delete records
+
+Delete via an instance:
+
+```php
+$category = Category::getById(1);
+$category?->delete();
+```
+
+Delete by primary key:
+
+```php
+Category::deleteById(1);
+```
+
+Delete by condition:
+
+```php
+Category::deleteAllWhere(
+    'name = ?',
+    ['Fiction']
+);
+```
+
+Delete with a richer SQL fragment:
+
+```php
+Category::deleteAllWhere(
+    'name = ? ORDER BY name DESC LIMIT 2',
+    ['Fiction']
+);
+```
+
+## Raw SQL
+
+Drop down to PDO statements when needed:
+
+```php
+$statement = Freshsauce\Model\Model::execute(
+    'SELECT * FROM categories WHERE id > ?',
+    [10]
+);
+
+$rows = $statement->fetchAll(PDO::FETCH_ASSOC);
+```
+
+## Validation
+
+Override `validate()` to enforce model rules before insert and update:
+
+```php
+class Category extends Freshsauce\Model\Model
+{
+    protected static $_tableName = 'categories';
+
+    public static function validate()
+    {
+        return true;
+    }
+}
+```
+
+Throw an exception from `validate()` whenever your application-specific rule fails, and the write will be aborted before insert or update.
+
+## MySQL example connection
+
+```php
+Freshsauce\Model\Model::connectDb(
+    'mysql:host=127.0.0.1;port=3306;dbname=categorytest',
+    'root',
+    ''
+);
+```
+
+## PostgreSQL example connection
+
+```php
+Freshsauce\Model\Model::connectDb(
+    'pgsql:host=127.0.0.1;port=5432;dbname=categorytest',
+    'postgres',
+    'postgres'
+);
+```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Requirements:
 - `ext-pdo`
 - A PDO driver such as `pdo_mysql` or `pdo_pgsql`
 
+Looking for fuller, example-led usage? See [EXAMPLE.md](EXAMPLE.md).
+
 ## Quick start
 
 Create a table:
@@ -90,6 +92,8 @@ Delete it:
 ```php
 $loaded->delete();
 ```
+
+For more end-to-end snippets, see [EXAMPLE.md](EXAMPLE.md).
 
 ## What you get
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Model ORM
 =========
 
-[![Build Status](https://scrutinizer-ci.com/g/freshsauce/model-orm-php/badges/build.png?b=master)](https://scrutinizer-ci.com/g/freshsauce/model-orm-php/build-status/master)
+[![CI](https://github.com/davebarnwell/model-orm-php/actions/workflows/ci.yml/badge.svg)](https://github.com/davebarnwell/model-orm-php/actions/workflows/ci.yml)
+[![PHP 8.3+](https://img.shields.io/badge/PHP-8.3%2B-777BB4?logo=php&logoColor=white)](https://www.php.net/)
 
 PHP Model class which provides:
 

--- a/README.md
+++ b/README.md
@@ -4,49 +4,35 @@ Model ORM
 [![CI](https://github.com/davebarnwell/model-orm-php/actions/workflows/ci.yml/badge.svg)](https://github.com/davebarnwell/model-orm-php/actions/workflows/ci.yml)
 [![PHP 8.3+](https://img.shields.io/badge/PHP-8.3%2B-777BB4?logo=php&logoColor=white)](https://www.php.net/)
 
-PHP Model class which provides:
+`Freshsauce\Model\Model` is a lightweight ORM-style base class for PHP applications that want database-backed models without committing to a large framework. Point it at a table, extend the base class, and you get CRUD operations, dynamic finders, counters, and raw query access with very little setup.
 
-* table column/property mapping
-* CRUD operations
-* dynamic finders and counters
-* raw queries with escaped parameters
-* results as instances of the Model class
-* exceptions on query error
+It is designed for projects that value straightforward PHP, direct PDO access, and a small abstraction layer that stays out of the way.
 
-Requirements & support
-----------------------
+## Why use it?
 
-* PHP >= 8.3
-* PDO with MySQL/MariaDB or PostgreSQL drivers
-* SQLite is supported in code paths but not covered by tests
+- Minimal setup: define a model class and table name, then start reading and writing rows.
+- PDO-first: use the ORM helpers when they help and drop down to raw SQL when they do not.
+- Familiar model flow: create, hydrate, validate, save, update, count, find, and delete.
+- Dynamic finders: call methods such as `find_by_name()`, `findOneByName()`, `count_by_name()`, and more.
+- Multi-database support: tested against MySQL/MariaDB and PostgreSQL, with SQLite code paths also supported.
 
-Usage
-=====
+## Installation
 
-With a MySQL database on localhost:
+Install from Composer:
 
-```sql
-CREATE DATABASE categorytest;
-CREATE TABLE `categories` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(120) DEFAULT NULL,
-  `updated_at` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
-  `created_at` timestamp NULL DEFAULT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+```bash
+composer require freshsauce/model
 ```
 
-```php
-require_once('vendor/autoload.php');
-Freshsauce\Model\Model::connectDb('mysql:dbname=categorytest;host=127.0.0.1', 'root', '');
+Requirements:
 
-// minimum model definition
-class Category extends Freshsauce\Model\Model {
-  static protected $_tableName = 'categories';
-}
-```
+- PHP `8.3+`
+- `ext-pdo`
+- A PDO driver such as `pdo_mysql` or `pdo_pgsql`
 
-PostgreSQL schema and connection:
+## Quick start
+
+Create a table:
 
 ```sql
 CREATE TABLE categories (
@@ -57,230 +43,159 @@ CREATE TABLE categories (
 );
 ```
 
-```php
-Freshsauce\Model\Model::connectDb('pgsql:host=127.0.0.1;port=5432;dbname=categorytest', 'postgres', 'postgres');
-```
-
-Testing
-=======
-
-Run PHPUnit with optional environment overrides for the DB connection:
-
-```
-MODEL_ORM_TEST_DSN=mysql:host=127.0.0.1;port=3306
-MODEL_ORM_TEST_USER=root
-MODEL_ORM_TEST_PASS=
-
-vendor/bin/phpunit -c phpunit.xml.dist
-```
-
-Static analysis:
-
-```
-vendor/bin/phpstan analyse -c phpstan.neon
-```
-
-Save & Update records
-=====================
+Connect and define a model:
 
 ```php
-$newCategory = new Category(array(
-  'name' => 'test'
-));
-$newCategory->save();
+require_once 'vendor/autoload.php';
+
+Freshsauce\Model\Model::connectDb(
+    'pgsql:host=127.0.0.1;port=5432;dbname=categorytest',
+    'postgres',
+    'postgres'
+);
+
+class Category extends Freshsauce\Model\Model
+{
+    protected static $_tableName = 'categories';
+}
 ```
 
-as Id is not set inserts the data as a new table row, `$newCategory->id` is set that of the row inserted post insert
+Create and save a record:
 
 ```php
-$newCategory->name = 'changed name';
-$newCategory->save();
+$category = new Category([
+    'name' => 'Sci-Fi',
+]);
+
+$category->save();
+
+echo $category->id;
 ```
 
-Now updates existing record
+Read it back:
 
 ```php
-new Category(array(
-  'name' => 'second test'
-))->save();
+$loaded = Category::getById($category->id);
 ```
 
-Explicit `->insert()` and `->update()` methods are available. `->save()` is a wrapper around these.
-If no dirty fields are present, `insert()` uses DEFAULT VALUES and `update()` returns false.
-
-All methods call `->validate()` before carrying out their operation. To add your own validation, override this method and throw an Exception on validation error.
-
-Find a single record by primary key
-===================================
-
-Returns an object for the matching row, or null if not found.
+Update it:
 
 ```php
-$cat = Category::getById(1);
+$loaded->name = 'Science Fiction';
+$loaded->save();
 ```
 
-Delete record(s)
-==================
-
-Via an instance method
+Delete it:
 
 ```php
-$cat = Category::getById(1);
-$cat?->delete();
+$loaded->delete();
 ```
 
-OR a Class method (primary key deletes only)
+## What you get
+
+### CRUD helpers
+
+The base model gives you the common record lifecycle methods:
+
+- `save()`
+- `insert()`
+- `update()`
+- `delete()`
+- `deleteById()`
+- `deleteAllWhere()`
+- `getById()`
+- `first()`
+- `last()`
+- `count()`
+
+Timestamp columns named `created_at` and `updated_at` are populated automatically on insert and update when present.
+
+### Dynamic finders and counters
+
+You can query using snake_case or CamelCase method names:
 
 ```php
-Category::deleteById(1);
-```
-    
-OR  all records matching a where clause
-
-```php
-Category::deleteAllWhere('name = ?', array('changed name'));
-```
-    
-OR  all records matching a where clause, specifying order and limits with more regular SQL
-
-```php
-Category::deleteAllWhere('name = ? ORDER BY name DESC LIMIT 2', array('changed name'));
-```
-
-Dynamic field name finders & counters
-=====================================
-
-Return an object for the first matching the name
-
-```php
-Category::findOne_by_name('changed name');
-```
-
-CamelCase alternatives are also supported:
-
-```php
-Category::findOneByName('changed name');
+Category::find_by_name('Science Fiction');
+Category::findOne_by_name('Science Fiction');
+Category::first_by_name(['Sci-Fi', 'Fantasy']);
+Category::lastByName(['Sci-Fi', 'Fantasy']);
+Category::count_by_name('Science Fiction');
 ```
 
-Return an object for the first match from the names
+### Custom where clauses
+
+When you need more control, fetch one or many records with SQL fragments:
 
 ```php
-Category::findOne_by_name(array('changed name', 'second test'));
+$one = Category::fetchOneWhere('id = ? OR name = ?', [1, 'Science Fiction']);
+
+$many = Category::fetchAllWhere('name IN (?, ?)', ['Sci-Fi', 'Fantasy']);
 ```
 
-Return an array of objects that match the name
+### Raw statements when needed
+
+If a query does not fit the model helpers, execute SQL directly through PDO:
 
 ```php
-Category::find_by_name('changed name');
+$statement = Freshsauce\Model\Model::execute(
+    'SELECT * FROM categories WHERE id > ?',
+    [10]
+);
+
+$rows = $statement->fetchAll(PDO::FETCH_ASSOC);
 ```
 
+## Validation hooks
+
+Override `validate()` in your model to enforce business rules before inserts and updates:
+
 ```php
-Category::findByName('changed name');
+class Category extends Freshsauce\Model\Model
+{
+    protected static $_tableName = 'categories';
+
+    public static function validate()
+    {
+        return true;
+    }
+}
 ```
 
-Return an array of objects that match the names
+Throw an exception from `validate()` to block invalid writes.
+
+## Database notes
+
+MySQL/MariaDB example connection:
 
 ```php
-Category::find_by_name(array('changed name', 'second test'));
-```
-
-Return the first record by ascending field 'name' as a Category object
-
-```php
-Category::first_by_name('john');  // can also pass an array of values to match
-```
-
-Return the last record in the table when sorted by ascending field 'name' as a Category object
-
-```php
-Category::last_by_name('john');   // can also pass an array of values to match
-```
-
-Return a count of records that match the name
-
-```php
-Category::count_by_name('changed name');
-```
-
-Return a count of records that match a set of values
-
-```php
-Category::count_by_name(array('changed name', 'second test'));
-```
-
-First, last & Count
-===================
-
-return the first record by ascending primary key as a Category object (or null)
-
-```php
-Category::first();
-```
-
-return the last record in the table when sorted by ascending primary key as a Category object (or null)
-
-```php
-Category::last();
-```
-
-Return the number of rows in the table
-
-```php
-Category::count();
-```
-
-Arbitrary Statements
-====================
-
-run an arbitrary statement returning a PDO statement handle to issue fetch etc... on
-
-```php
-$st = Freshsauce\Model\Model::execute(
-  'SELECT * FROM categories WHERE id = ? AND id = ? AND id > ?',
-  array(1, 2, 6)
+Freshsauce\Model\Model::connectDb(
+    'mysql:host=127.0.0.1;port=3306;dbname=categorytest',
+    'root',
+    ''
 );
 ```
 
-Find One Or All
-===============
-
-Custom SQL after the WHERE keyword returning the first match or all matches as Model instances.
-`fetchOneWhere()` returns null when no rows match.
-
-fetch one Category object with a custom WHERE ... clause
+PostgreSQL example connection:
 
 ```php
-$cat = Category::fetchOneWhere('id = ? OR name = ?', array(1, 'test'));
+Freshsauce\Model\Model::connectDb(
+    'pgsql:host=127.0.0.1;port=5432;dbname=categorytest',
+    'postgres',
+    'postgres'
+);
 ```
 
-Fetch array of Category objects with a custom WHERE ... clause
+SQLite is supported in the library code paths, but the automated test suite currently covers MySQL/MariaDB and PostgreSQL.
 
-```php
-$cat = Category::fetchAllWhere('id = ? OR name = ?', array(1, 'second test'));
-```
-    
-Fetch array of Category objects, as above but this time getting the second one if it exists ordered by ascending name
+## Quality
 
-```php
-$cat = Category::fetchAllWhere('id = ? OR name = ? ORDER BY name ASC LIMIT 1,1', array(1, 'second test'));
-```
+The repository ships with:
 
-General SQL Helpers
-===================
+- PHPUnit coverage for the core model behavior
+- PHPStan static analysis
+- PHP-CS-Fixer formatting checks
+- GitHub Actions CI for pull requests and pushes
 
-Generate placeholders for an IN clause
+## Contributing
 
-```php
-$params = array(1, 2, 3, 4);
-$placeholders = Freshsauce\Model\Model::createInClausePlaceholders($params); // returns '?,?,?,?'
-Category::fetchAllWhere('id IN (' . $placeholders . ')', $params);
-```
-
-Take a date string or unix datetime number and return a string that can be assigned to a TIMESTAMP or DATETIME field
-date strings are parsed into a unix date via PHP's incredibly flexible strtotime()
-
-```php
-Freshsauce\Model\Model::datetimeToMysqldatetime('2012 Sept 13th 12:00');
-Freshsauce\Model\Model::datetimeToMysqldatetime('next Monday');
-Freshsauce\Model\Model::datetimeToMysqldatetime(gmdate());
-```
+Development setup, testing commands, pull request expectations, and contribution terms are documented in [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Looking for fuller, example-led usage? See [EXAMPLE.md](EXAMPLE.md).
 
 ## Quick start
 
-Create a table:
+Create a table. This quick-start example uses PostgreSQL syntax:
 
 ```sql
 CREATE TABLE categories (
@@ -44,6 +44,8 @@ CREATE TABLE categories (
   created_at TIMESTAMP NULL
 );
 ```
+
+If you are using MySQL or MariaDB, use `INT AUTO_INCREMENT PRIMARY KEY` for the `id` column instead.
 
 Connect and define a model:
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,11 @@
         bootstrap="vendor/autoload.php"
         colors="true"
         cacheDirectory=".phpunit.cache">
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
     <testsuites>
         <testsuite name="Freshsauce/Model Tests">
             <directory>tests</directory>

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -484,7 +484,7 @@ class Model
     /**
      * Find records with the matching primary key
      *
-     * @param string $id
+     * @param int|string $id
      *
      * @return object[] of objects for matching records
      */

--- a/test-src/Model/Category.php
+++ b/test-src/Model/Category.php
@@ -4,6 +4,10 @@ namespace App\Model;
 
 /**
  * @method static array find_by_name($match)
+ * @method static self|null findOne_by_name($match)
+ * @method static self|null first_by_name($match)
+ * @method static self|null last_by_name($match)
+ * @method static int count_by_name($match)
  * @method static array findByName($match)
  * @method static self|null findOneByName($match)
  * @method static self|null firstByName($match)

--- a/tests/Model/CategoryTest.php
+++ b/tests/Model/CategoryTest.php
@@ -75,9 +75,23 @@ class CategoryTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::save
-     */
+    public function setUp(): void
+    {
+        if (self::$driverName === 'mysql') {
+            Freshsauce\Model\Model::execute('TRUNCATE TABLE `categories`');
+        } elseif (self::$driverName === 'pgsql') {
+            Freshsauce\Model\Model::execute('TRUNCATE TABLE "categories" RESTART IDENTITY');
+        }
+    }
+
+    private function createCategory(string $name, array $data = []): App\Model\Category
+    {
+        $category = new App\Model\Category(array_merge(['name' => $name], $data));
+        $category->save();
+
+        return $category;
+    }
+
     public function testCreate(): void
     {
         $_name    = 'Fiction';
@@ -93,17 +107,10 @@ class CategoryTest extends TestCase
         $this->assertNotEmpty($category->updated_at);
     }
 
-    /**
-     * @covers ::getById
-     */
     public function testCreateAndGetById(): void
     {
         $_name    = 'SciFi';
-        $category = new App\Model\Category(array(
-            'name' => $_name
-        ));
-
-        $category->save(); // no Id so will insert
+        $category = $this->createCategory($_name);
 
         $this->assertEquals($category->name, $_name);
         $this->assertNotEmpty($category->id);
@@ -117,26 +124,16 @@ class CategoryTest extends TestCase
         $this->assertNotEmpty($category->updated_at);
     }
 
-    /**
-     * @covers ::fetchOneWhere
-     */
     public function testFetchOneWhereReturnsNullWhenMissing(): void
     {
         $missing = App\Model\Category::fetchOneWhere('name = ?', ['__missing__' . uniqid('', true)]);
         $this->assertNull($missing);
     }
 
-    /**
-     * @covers ::save
-     */
     public function testCreateAndModify(): void
     {
         $_name    = 'Literature';
-        $category = new App\Model\Category(array(
-            'name' => $_name
-        ));
-
-        $category->save(); // no Id so will insert
+        $category = $this->createCategory($_name);
 
         $this->assertEquals($category->name, $_name);
         $this->assertNotEmpty($category->id);
@@ -157,9 +154,6 @@ class CategoryTest extends TestCase
 
     }
 
-    /**
-     * @covers ::insert
-     */
     public function testInsertWithDefaultValuesWhenNoDirtyFields(): void
     {
         $category = new App\Model\Category();
@@ -169,24 +163,14 @@ class CategoryTest extends TestCase
         $this->assertNotEmpty($category->id);
     }
 
-    /**
-     * @covers ::update
-     */
     public function testUpdateWithoutDirtyFieldsReturnsFalse(): void
     {
-        $category = new App\Model\Category(array(
-            'name' => 'Nonfiction'
-        ));
-        $category->save();
+        $category = $this->createCategory('Nonfiction');
         $category->clearDirtyFields();
 
         $this->assertFalse($category->update(false));
     }
 
-    /**
-     * @covers ::__callStatic
-     * @covers ::fetchAllWhereMatchingSingleField
-     */
     public function testFetchAllWhere(): void
     {
         // Create some categories
@@ -208,12 +192,108 @@ class CategoryTest extends TestCase
         $this->assertCount(count($_names), $categories);
     }
 
-    /**
-     * @covers ::__callStatic
-     * @covers ::fetchAllWhereMatchingSingleField
-     * @covers ::fetchOneWhereMatchingSingleField
-     * @covers ::countAllWhere
-     */
+    public function testModelStateHelpers(): void
+    {
+        $category = new App\Model\Category();
+        $category->clearDirtyFields();
+
+        $this->assertTrue($category->hasData());
+        $this->assertTrue($category->dataPresent());
+        $this->assertTrue(isset($category->name));
+        $this->assertNull($category->name);
+        $this->assertFalse($category->isFieldDirty('name'));
+
+        $category->name = 'History';
+        $this->assertTrue($category->isFieldDirty('name'));
+
+        $data = $category->toArray();
+        $this->assertSame('History', $data['name']);
+        $this->assertSame(['id', 'name', 'updated_at', 'created_at'], $category->__sleep());
+
+        $category->clear();
+        $this->assertNull($category->name);
+        $this->assertFalse($category->isFieldDirty('name'));
+    }
+
+    public function testMagicGetThrowsForMissingDataAndUnknownField(): void
+    {
+        $reflection = new ReflectionClass(App\Model\Category::class);
+        /** @var App\Model\Category $categoryWithoutConstructor */
+        $categoryWithoutConstructor = $reflection->newInstanceWithoutConstructor();
+
+        $this->assertFalse($categoryWithoutConstructor->hasData());
+
+        try {
+            $categoryWithoutConstructor->dataPresent();
+            $this->fail('Expected missing data exception.');
+        } catch (Exception $exception) {
+            $this->assertSame('No data', $exception->getMessage());
+        }
+
+        $category = new App\Model\Category();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Undefined property via __get(): unknown_field');
+        $category->__get('unknown_field');
+    }
+
+    public function testRecordLifecycleHelpers(): void
+    {
+        $first = $this->createCategory('Alpha');
+        $second = $this->createCategory('Beta');
+        $third = $this->createCategory('Gamma');
+
+        $this->assertNotNull($first->id);
+        $this->assertNotNull($second->id);
+        $this->assertNotNull($third->id);
+
+        $this->assertSame(3, App\Model\Category::count());
+        $this->assertSame($first->id, App\Model\Category::first()?->id);
+        $this->assertSame($third->id, App\Model\Category::last()?->id);
+
+        /** @var App\Model\Category[] $found */
+        $found = App\Model\Category::find((int) $second->id);
+        $this->assertCount(1, $found);
+        $this->assertSame($second->id, $found[0]->id);
+
+        $matching = App\Model\Category::fetchAllWhere('name IN (?, ?)', ['Alpha', 'Gamma']);
+        $this->assertCount(2, $matching);
+
+        $this->assertTrue($third->delete());
+        $this->assertTrue(App\Model\Category::deleteById((int) $second->id));
+        $this->assertFalse(App\Model\Category::deleteById(999999));
+
+        $statement = App\Model\Category::deleteAllWhere('name = ?', ['Alpha']);
+        $this->assertSame(1, $statement->rowCount());
+        $this->assertSame(0, App\Model\Category::count());
+    }
+
+    public function testDynamicFindersSnakeCase(): void
+    {
+        $_names = [
+            'Snake_' . uniqid('a_', true),
+            'Snake_' . uniqid('b_', true),
+        ];
+        foreach ($_names as $_name) {
+            $this->createCategory($_name);
+        }
+
+        $one = App\Model\Category::findOne_by_name($_names[0]);
+        $this->assertNotNull($one);
+        $this->assertSame($_names[0], $one->name);
+
+        $first = App\Model\Category::first_by_name($_names);
+        $this->assertNotNull($first);
+        $this->assertContains($first->name, $_names);
+
+        $last = App\Model\Category::last_by_name($_names);
+        $this->assertNotNull($last);
+        $this->assertContains($last->name, $_names);
+
+        $count = App\Model\Category::count_by_name($_names);
+        $this->assertSame(count($_names), $count);
+    }
+
     public function testDynamicFindersCamelCase(): void
     {
         $_names = [
@@ -244,5 +324,32 @@ class CategoryTest extends TestCase
 
         $count = App\Model\Category::countByName($_names);
         $this->assertEquals(count($_names), $count);
+    }
+
+    public function testInsertAllowsExplicitPrimaryKey(): void
+    {
+        $category = new App\Model\Category([
+            'id' => 999,
+            'name' => 'With explicit id',
+        ]);
+
+        $this->assertTrue($category->insert(false, true));
+        $this->assertSame(999, (int) $category->id);
+        $this->assertSame(999, (int) App\Model\Category::getById(999)?->id);
+    }
+
+    public function testUtilityHelpers(): void
+    {
+        $this->assertSame('?,?,?', App\Model\Category::createInClausePlaceholders([1, 2, 3]));
+        $this->assertSame('1970-01-01 00:00:00', App\Model\Category::datetimeToMysqldatetime('not-a-date'));
+        $this->assertSame('2023-11-14 22:13:20', App\Model\Category::datetimeToMysqldatetime(1700000000));
+    }
+
+    public function testUnknownDynamicMethodThrows(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Freshsauce\Model\Model not such static method[doesNotExist]');
+
+        App\Model\Category::__callStatic('doesNotExist', ['value']);
     }
 }

--- a/tests/Model/CategoryTest.php
+++ b/tests/Model/CategoryTest.php
@@ -248,13 +248,13 @@ class CategoryTest extends TestCase
         $this->assertNotNull($third->id);
 
         $this->assertSame(3, App\Model\Category::count());
-        $this->assertSame($first->id, App\Model\Category::first()?->id);
-        $this->assertSame($third->id, App\Model\Category::last()?->id);
+        $this->assertSame((int) $first->id, (int) App\Model\Category::first()?->id);
+        $this->assertSame((int) $third->id, (int) App\Model\Category::last()?->id);
 
         /** @var App\Model\Category[] $found */
         $found = App\Model\Category::find((int) $second->id);
         $this->assertCount(1, $found);
-        $this->assertSame($second->id, $found[0]->id);
+        $this->assertSame((int) $second->id, (int) $found[0]->id);
 
         $matching = App\Model\Category::fetchAllWhere('name IN (?, ?)', ['Alpha', 'Gamma']);
         $this->assertCount(2, $matching);


### PR DESCRIPTION
This PR refreshes the project in three connected areas: automated quality checks, test coverage, and developer-facing documentation. The original problem was not just that the test suite was thin, but that the repository also lacked a modern pull request workflow story and the public docs no longer presented the package as clearly as they should.

From a maintenance perspective, the effect was that important behavior in the base model class was either untested or only lightly exercised, one of the existing tests depended on state left behind by earlier tests, and the repository landing page still pointed at older build tooling rather than the actual GitHub Actions workflow. That combination made the package harder to trust for contributors and less compelling for new users evaluating it.

The root causes were straightforward: the codebase had not been revisited in a while, so the tests had not kept pace with the model surface area, PHPUnit coverage configuration had not been modernized, and the documentation had gradually mixed package messaging with contribution workflow details. The result was a repository that worked, but did not advertise or verify itself as strongly as it should.

The testing changes stabilize the suite by resetting table state before each test and expand coverage around model state helpers, magic accessors, delete flows, snake_case and CamelCase dynamic finder variants, explicit primary-key inserts, and utility helpers. The branch also adds the PHPUnit source filter so coverage reporting works with current PHPUnit versions, and corrects the `find()` docblock signature plus the test-model annotations required for clean static analysis.

The CI changes update the existing GitHub Actions workflow rather than replacing it outright. Static analysis and formatting now run once in a dedicated `quality` job, while database-backed PHPUnit runs continue in a matrix across PHP 8.3 and 8.4 with MySQL and PostgreSQL. Service health checks and explicit readiness failures were added so database startup problems fail clearly instead of producing less useful downstream test errors.

The documentation changes are broader than a simple badge update. The README is now more package-facing and promotional, with a cleaner explanation of what the ORM offers, a tighter quick-start path, and clearer feature framing. Contributor process material has been moved into a dedicated `CONTRIBUTING.md` with setup instructions, validation commands, pull request expectations, and standard contribution terms. A new `EXAMPLE.md` has also been added and linked from the README so users can jump straight from overview to example-led usage for common model flows.

Validation was done locally against PostgreSQL. The updated suite now runs as 15 tests and 76 assertions, and with Xdebug enabled it reports 81.53% line coverage and 73.08% method coverage for `src/Model/Model.php`. I also reran PHPStan and the PHP-CS-Fixer dry run successfully. The MySQL path was not rerun locally because the MariaDB container on this machine is not publishing port 3306 to the host, so the MySQL validation for this branch is expected to come from the GitHub Actions matrix.
