### PR TITLE
ci: add CalVer release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: Release
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.event.pull_request.base.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: >
+      github.event.pull_request.merged == true &&
+      (github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'master')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out merged commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: git fetch --force --tags origin
+
+      - name: Determine CalVer tag
+        id: calver
+        env:
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+
+          existing_tag="$(git tag --points-at "$MERGE_COMMIT_SHA" --list 'v[0-9]*' | sort -V | head -n 1)"
+
+          if [ -n "$existing_tag" ]; then
+            tag="$existing_tag"
+          else
+            base="$(date -u +'%Y.%m.%d')"
+            exact_exists=0
+            max_suffix=0
+
+            while IFS= read -r existing; do
+              if [ "$existing" = "v$base" ]; then
+                exact_exists=1
+                continue
+              fi
+
+              suffix="${existing#v$base.}"
+              if ! printf '%s' "$suffix" | grep -Eq '^[0-9]+$'; then
+                continue
+              fi
+
+              if [ "$suffix" -gt "$max_suffix" ]; then
+                max_suffix="$suffix"
+              fi
+            done < <(git tag -l "v$base" "v$base.*" | sort -V)
+
+            if [ "$exact_exists" -eq 0 ] && [ "$max_suffix" -eq 0 ]; then
+              tag="v$base"
+            else
+              tag="v$base.$((max_suffix + 1))"
+            fi
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        env:
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          TAG: ${{ steps.calver.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists on origin"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" "$MERGE_COMMIT_SHA" -m "Release $TAG"
+          git push origin "refs/tags/$TAG"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          TAG: ${{ steps.calver.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists"
+            exit 0
+          fi
+
+          gh release create "$TAG" \
+            --target "$MERGE_COMMIT_SHA" \
+            --generate-notes \
+            --title "$TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
         id: calver
         env:
           MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          MERGED_AT: ${{ github.event.pull_request.merged_at }}
         run: |
           set -euo pipefail
 
@@ -39,13 +40,13 @@ jobs:
             git tag --points-at "$MERGE_COMMIT_SHA" |
             grep -E '^v[0-9]{2}\.[0-9]{2}\.[0-9]{2}\.[0-9]+$' |
             sort -V |
-            head -n 1 || true
+            tail -n 1 || true
           )"
 
           if [ -n "$existing_tag" ]; then
             tag="$existing_tag"
           else
-            base="$(date -u +'%y.%m.%d')"
+            base="$(date -u -d "$MERGED_AT" +'%y.%m.%d')"
             max_suffix=0
 
             while IFS= read -r existing; do
@@ -72,8 +73,14 @@ jobs:
           set -euo pipefail
 
           if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists on origin"
-            exit 0
+            remote_sha="$(git rev-list -n 1 "$TAG")"
+            if [ "$remote_sha" = "$MERGE_COMMIT_SHA" ]; then
+              echo "Tag $TAG already exists on origin and points to the expected commit"
+              exit 0
+            fi
+
+            echo "Error: Tag $TAG already exists on origin but points to $remote_sha instead of $MERGE_COMMIT_SHA"
+            exit 1
           fi
 
           git config user.name "github-actions[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,21 +35,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          existing_tag="$(git tag --points-at "$MERGE_COMMIT_SHA" --list 'v[0-9]*' | sort -V | head -n 1)"
+          existing_tag="$(
+            git tag --points-at "$MERGE_COMMIT_SHA" |
+            grep -E '^v[0-9]{2}\.[0-9]{2}\.[0-9]{2}\.[0-9]+$' |
+            sort -V |
+            head -n 1 || true
+          )"
 
           if [ -n "$existing_tag" ]; then
             tag="$existing_tag"
           else
-            base="$(date -u +'%Y.%m.%d')"
-            exact_exists=0
+            base="$(date -u +'%y.%m.%d')"
             max_suffix=0
 
             while IFS= read -r existing; do
-              if [ "$existing" = "v$base" ]; then
-                exact_exists=1
-                continue
-              fi
-
               suffix="${existing#v$base.}"
               if ! printf '%s' "$suffix" | grep -Eq '^[0-9]+$'; then
                 continue
@@ -58,13 +57,9 @@ jobs:
               if [ "$suffix" -gt "$max_suffix" ]; then
                 max_suffix="$suffix"
               fi
-            done < <(git tag -l "v$base" "v$base.*" | sort -V)
+            done < <(git tag -l "v$base.*" | sort -V)
 
-            if [ "$exact_exists" -eq 0 ] && [ "$max_suffix" -eq 0 ]; then
-              tag="v$base"
-            else
-              tag="v$base.$((max_suffix + 1))"
-            fi
+            tag="v$base.$((max_suffix + 1))"
           fi
 
           echo "tag=$tag" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Improve identifier quoting and driver-specific schema discovery.
 - Update tests to support configurable DB backends.
 - Add GitHub Actions CI matrix for PHP and database drivers.
+- Add automatic CalVer tagging and GitHub releases for merged PRs.

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The repository ships with:
 - PHPStan static analysis
 - PHP-CS-Fixer formatting checks
 - GitHub Actions CI for pull requests and pushes
-- Automatic CalVer tags and GitHub releases for merged PRs to `main`/`master`
+- Automatic `vYY.MM.DD.n` CalVer tags and GitHub releases for merged PRs to `main`/`master`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ The repository ships with:
 - PHPStan static analysis
 - PHP-CS-Fixer formatting checks
 - GitHub Actions CI for pull requests and pushes
+- Automatic CalVer tags and GitHub releases for merged PRs to `main`/`master`
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
This change adds a dedicated GitHub Actions release workflow that runs when a pull request is merged into `main` or `master`. After merge, the workflow checks out the merge commit, computes a deterministic `vYY.MM.DD.n` CalVer tag for that commit, pushes the tag, and creates a GitHub release with generated notes.

Without this automation, merges complete without any release artifact, which means consumers do not get a consistent version tag or release record for shipped changes. The immediate user-facing effect is that merged work is harder to consume and audit because there is no standardized post-merge versioning step.

The root cause is that the repository only had validation CI and no post-merge release pipeline. There was no workflow listening for merged pull requests, no logic for generating CalVer tags, and no release creation step tied to the merge commit.

The fix introduces a separate `release.yml` workflow so validation and release responsibilities stay isolated. The workflow only runs for merged pull requests targeting `main` or `master`, reuses the highest existing `vYY.MM.DD.n` tag already attached to the merge commit on reruns, otherwise derives the date portion from the PR merge timestamp and creates the next suffix for that day, verifies that any pre-existing remote tag points at the expected merge commit, and then creates the corresponding GitHub release. The README and changelog were updated to document the new behavior.

## Validation
- Parsed `.github/workflows/release.yml` successfully with PyYAML
- Ran `vendor/bin/phpunit -c phpunit.xml.dist`
