### PR TITLE
fix: isolate statement cache and fix SQLite inserts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           php-version: "8.3"
           coverage: none
-          extensions: pdo, pdo_mysql, pdo_pgsql
+          extensions: pdo, pdo_mysql, pdo_pgsql, pdo_sqlite
 
       - name: Install dependencies
         run: composer install --no-interaction --no-progress --prefer-dist
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ["8.3", "8.4"]
-        db: ["mysql", "postgres"]
+        db: ["mysql", "postgres", "sqlite"]
 
     services:
       mysql:
@@ -71,7 +71,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: none
-          extensions: pdo, pdo_mysql, pdo_pgsql
+          extensions: pdo, pdo_mysql, pdo_pgsql, pdo_sqlite
 
       - name: Install dependencies
         run: composer install --no-interaction --no-progress --prefer-dist
@@ -82,10 +82,14 @@ jobs:
             echo "MODEL_ORM_TEST_DSN=mysql:host=127.0.0.1;port=3306" >> "$GITHUB_ENV"
             echo "MODEL_ORM_TEST_USER=root" >> "$GITHUB_ENV"
             echo "MODEL_ORM_TEST_PASS=" >> "$GITHUB_ENV"
-          else
+          elif [ "${{ matrix.db }}" = "postgres" ]; then
             echo "MODEL_ORM_TEST_DSN=pgsql:host=127.0.0.1;port=5432;dbname=categorytest" >> "$GITHUB_ENV"
             echo "MODEL_ORM_TEST_USER=postgres" >> "$GITHUB_ENV"
             echo "MODEL_ORM_TEST_PASS=postgres" >> "$GITHUB_ENV"
+          else
+            echo "MODEL_ORM_TEST_DSN=sqlite::memory:" >> "$GITHUB_ENV"
+            echo "MODEL_ORM_TEST_USER=" >> "$GITHUB_ENV"
+            echo "MODEL_ORM_TEST_PASS=" >> "$GITHUB_ENV"
           fi
 
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is designed for projects that value straightforward PHP, direct PDO access, a
 - PDO-first: use the ORM helpers when they help and drop down to raw SQL when they do not.
 - Familiar model flow: create, hydrate, validate, save, update, count, find, and delete.
 - Dynamic finders: call methods such as `findByName()`, `findOneByName()`, `countByName()`, and more.
-- Multi-database support: tested against MySQL/MariaDB and PostgreSQL, with SQLite code paths also supported.
+- Multi-database support: tested against MySQL/MariaDB, PostgreSQL, and SQLite.
 
 ## Installation
 
@@ -193,7 +193,7 @@ Freshsauce\Model\Model::connectDb(
 );
 ```
 
-SQLite is supported in the library code paths, but the automated test suite currently covers MySQL/MariaDB and PostgreSQL.
+SQLite is supported in the library and covered by the automated test suite alongside MySQL/MariaDB and PostgreSQL.
 
 ## Quality
 

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -41,9 +41,9 @@ class Model
     // sub class must also redeclare public static $_db;
 
     /**
-     * @var \PDOStatement[]
+     * @var array<int, array<string, \PDOStatement>>
      */
-    protected static $_stmt = array(); // prepared statements cache
+    protected static $_stmt = array(); // prepared statements cache keyed by PDO connection and SQL
 
     /**
      * @var string|null
@@ -226,10 +226,13 @@ class Model
      */
     public static function connectDb(string $dsn, string $username, string $password, array $driverOptions = array()): void
     {
+        $previousDb = static::$_db;
+        if ($previousDb instanceof \PDO) {
+            unset(static::$_stmt[spl_object_id($previousDb)]);
+        }
         static::$_db = new \PDO($dsn, $username, $password, $driverOptions);
         static::$_db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION); // Set Errorhandling to Exception
         static::$_identifier_quote_character = null;
-        static::$_stmt = array();
         self::$_tableColumns = array();
         static::_setup_identifier_quote_character();
     }
@@ -966,7 +969,7 @@ class Model
             return false;
         }
 
-        if ($set['sql'] === '') {
+        if (count($set['columns']) === 0) {
             if ($driver === 'sqlite' || $driver === 'sqlite2') {
                 $query = 'INSERT INTO ' . static::_quote_identifier(static::$_tableName) . ' DEFAULT VALUES';
                 $st = static::execute($query);
@@ -975,7 +978,9 @@ class Model
                 $st = static::execute($query);
             }
         } else {
-            $query = 'INSERT INTO ' . static::_quote_identifier(static::$_tableName) . ' SET ' . $set['sql'];
+            $query = 'INSERT INTO ' . static::_quote_identifier(static::$_tableName) .
+                ' (' . implode(', ', $set['columns']) . ')' .
+                ' VALUES (' . implode(', ', $set['values']) . ')';
             $st    = static::execute($query, $set['params']);
         }
         if ($st->rowCount() == 1) {
@@ -1051,11 +1056,15 @@ class Model
         if (!$db) {
             throw new \Exception('No database connection setup');
         }
-        if (!isset(static::$_stmt[$query])) {
-            // cache prepared query if not seen before
-            static::$_stmt[$query] = $db->prepare($query);
+        $connectionId = spl_object_id($db);
+        if (!isset(static::$_stmt[$connectionId])) {
+            static::$_stmt[$connectionId] = array();
         }
-        return static::$_stmt[$query]; // return cache copy
+        if (!isset(static::$_stmt[$connectionId][$query])) {
+            // cache prepared query if not seen before
+            static::$_stmt[$connectionId][$query] = $db->prepare($query);
+        }
+        return static::$_stmt[$connectionId][$query]; // return cache copy
     }
 
     /**

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -1147,7 +1147,7 @@ class Model
     protected static function supportsUpdateLimit()
     {
         $driver = static::getDriverName();
-        return ($driver === 'mysql' || $driver === 'sqlite' || $driver === 'sqlite2');
+        return ($driver === 'mysql');
     }
 
     /**
@@ -1159,7 +1159,7 @@ class Model
     protected static function supportsDeleteLimit()
     {
         $driver = static::getDriverName();
-        return ($driver === 'mysql' || $driver === 'sqlite' || $driver === 'sqlite2');
+        return ($driver === 'mysql');
     }
 
     /**

--- a/test-src/Model/IsolatedConnectionCategoryA.php
+++ b/test-src/Model/IsolatedConnectionCategoryA.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Model;
+
+/**
+ * @property int|null $id
+ * @property string|null $name
+ */
+class IsolatedConnectionCategoryA extends \Freshsauce\Model\Model
+{
+    public static $_db;
+
+    protected static $_tableName = 'items';
+}

--- a/test-src/Model/IsolatedConnectionCategoryB.php
+++ b/test-src/Model/IsolatedConnectionCategoryB.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Model;
+
+/**
+ * @property int|null $id
+ * @property string|null $name
+ */
+class IsolatedConnectionCategoryB extends \Freshsauce\Model\Model
+{
+    public static $_db;
+
+    protected static $_tableName = 'items';
+}

--- a/test-src/Model/SqliteCategory.php
+++ b/test-src/Model/SqliteCategory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Model;
+
+/**
+ * @property int|null $id
+ * @property string|null $name
+ * @property string|null $updated_at
+ * @property string|null $created_at
+ */
+class SqliteCategory extends \Freshsauce\Model\Model
+{
+    public static $_db;
+
+    protected static $_tableName = 'categories';
+}

--- a/tests/Model/CategoryTest.php
+++ b/tests/Model/CategoryTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 class CategoryTest extends TestCase
 {
     private const TEST_DB_NAME = 'categorytest';
+    private const SQLITE_SEQUENCE_TABLE = 'sqlite_sequence';
     private static ?string $driverName = null;
 
     /**
@@ -53,6 +54,16 @@ class CategoryTest extends TestCase
                  "created_at" TIMESTAMP NULL
                )',
             ];
+        } elseif (self::$driverName === 'sqlite') {
+            $sql_setup = [
+                'DROP TABLE IF EXISTS `categories`',
+                'CREATE TABLE `categories` (
+                 `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+                 `name` VARCHAR(120) NULL,
+                 `updated_at` TEXT NULL,
+                 `created_at` TEXT NULL
+               )',
+            ];
         } else {
             throw new RuntimeException('Unsupported PDO driver for tests: ' . self::$driverName);
         }
@@ -81,6 +92,12 @@ class CategoryTest extends TestCase
             Freshsauce\Model\Model::execute('TRUNCATE TABLE `categories`');
         } elseif (self::$driverName === 'pgsql') {
             Freshsauce\Model\Model::execute('TRUNCATE TABLE "categories" RESTART IDENTITY');
+        } elseif (self::$driverName === 'sqlite') {
+            Freshsauce\Model\Model::execute('DELETE FROM `categories`');
+            Freshsauce\Model\Model::execute(
+                'DELETE FROM `' . self::SQLITE_SEQUENCE_TABLE . '` WHERE `name` = ?',
+                ['categories']
+            );
         }
     }
 

--- a/tests/Model/SqliteModelTest.php
+++ b/tests/Model/SqliteModelTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class SqliteModelTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        App\Model\SqliteCategory::connectDb('sqlite::memory:', '', '');
+        App\Model\SqliteCategory::execute(
+            'CREATE TABLE categories (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NULL,
+                updated_at TEXT NULL,
+                created_at TEXT NULL
+            )'
+        );
+    }
+
+    protected function setUp(): void
+    {
+        App\Model\SqliteCategory::execute('DELETE FROM `categories`');
+        App\Model\SqliteCategory::execute('DELETE FROM sqlite_sequence WHERE name = ?', ['categories']);
+    }
+
+    public function testSqliteInsertWithDirtyFields(): void
+    {
+        /** @var App\Model\SqliteCategory $category */
+        $category = new App\Model\SqliteCategory([
+            'name' => 'SQLite Fiction',
+        ]);
+
+        $this->assertTrue($category->save());
+        $this->assertSame('SQLite Fiction', $category->name);
+        $this->assertSame('1', (string) $category->id);
+        $this->assertNotEmpty($category->created_at);
+        $this->assertNotEmpty($category->updated_at);
+
+        /** @var App\Model\SqliteCategory|null $reloaded */
+        $reloaded = App\Model\SqliteCategory::getById((int) $category->id);
+
+        $this->assertNotNull($reloaded);
+        $this->assertSame('SQLite Fiction', $reloaded->name);
+    }
+
+    public function testPreparedStatementsStayBoundToTheirOwnConnection(): void
+    {
+        App\Model\IsolatedConnectionCategoryA::connectDb('sqlite::memory:', '', '');
+        App\Model\IsolatedConnectionCategoryB::connectDb('sqlite::memory:', '', '');
+
+        App\Model\IsolatedConnectionCategoryA::execute(
+            'CREATE TABLE items (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NULL
+            )'
+        );
+        App\Model\IsolatedConnectionCategoryB::execute(
+            'CREATE TABLE items (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NULL
+            )'
+        );
+
+        App\Model\IsolatedConnectionCategoryA::execute('INSERT INTO `items` (`name`) VALUES (?)', ['from-a']);
+        App\Model\IsolatedConnectionCategoryB::execute('INSERT INTO `items` (`name`) VALUES (?)', ['from-b']);
+
+        /** @var App\Model\IsolatedConnectionCategoryA|null $fromA */
+        $fromA = App\Model\IsolatedConnectionCategoryA::fetchOneWhere('`id` = ?', [1]);
+        /** @var App\Model\IsolatedConnectionCategoryB|null $fromB */
+        $fromB = App\Model\IsolatedConnectionCategoryB::fetchOneWhere('`id` = ?', [1]);
+
+        $this->assertNotNull($fromA);
+        $this->assertNotNull($fromB);
+        $this->assertSame('from-a', $fromA->name);
+        $this->assertSame('from-b', $fromB->name);
+    }
+}

--- a/tests/Model/SqliteModelTest.php
+++ b/tests/Model/SqliteModelTest.php
@@ -1,11 +1,16 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\SkippedTestSuiteError;
 
 class SqliteModelTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
+        if (!in_array('sqlite', \PDO::getAvailableDrivers(), true)) {
+            throw new SkippedTestSuiteError('The pdo_sqlite extension is required to run SQLite-specific tests.');
+        }
+
         App\Model\SqliteCategory::connectDb('sqlite::memory:', '', '');
         App\Model\SqliteCategory::execute(
             'CREATE TABLE categories (


### PR DESCRIPTION
This change fixes the SQLite-specific correctness gaps in the base model layer and expands automated coverage so every advertised backend is exercised in CI.

SQLite was documented as supported, but inserts with dirty fields still used MySQL-style `INSERT ... SET ...` SQL in the shared insert path. That meant a normal `save()` call failed on SQLite even though the rest of the model code advertised support for it. The insert builder now emits portable `INSERT INTO (...) VALUES (...)` SQL for non-PostgreSQL writes while preserving the existing PostgreSQL `RETURNING` path and the empty-row `DEFAULT VALUES` handling.

The patch also fixes prepared statement caching when subclasses redeclare `$_db` to use separate PDO connections. Statement caching was keyed only by SQL string, so two models using identical queries on different connections could accidentally share the same prepared statement handle. The cache is now scoped by PDO object identity and query text, which keeps statements isolated to the connection that prepared them.

To make the backend support claims real, the shared `CategoryTest` integration suite now supports SQLite as well as MySQL and PostgreSQL. The workflow matrix has been extended to run the PHPUnit suite against all three database types, and the SQLite-specific test coverage remains in place for connection isolation. The SQLite path also no longer appends `LIMIT` to `UPDATE` and `DELETE`, which avoids another engine-specific syntax failure.

Validation:

- `vendor/bin/phpunit -c phpunit.xml.dist`
- `MODEL_ORM_TEST_DSN='pgsql:host=127.0.0.1;port=5432;dbname=categorytest' MODEL_ORM_TEST_USER='postgres' MODEL_ORM_TEST_PASS='postgres' vendor/bin/phpunit -c phpunit.xml.dist`
- `MODEL_ORM_TEST_DSN='sqlite::memory:' MODEL_ORM_TEST_USER='' MODEL_ORM_TEST_PASS='' vendor/bin/phpunit -c phpunit.xml.dist`
- `vendor/bin/phpstan analyse -c phpstan.neon`
