### PR TITLE
refactor: implement phase 3 ORM hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ The base model gives you the methods most applications reach for first:
 
 If your table includes `created_at` and `updated_at`, they are populated automatically on insert and update.
 
+Timestamps are generated in UTC using the `Y-m-d H:i:s` format. SQLite stores those values as text, while MySQL/MariaDB and PostgreSQL accept them in timestamp-style columns.
+
 ### Dynamic finders and counters
 
 Build expressive queries straight from method names:
@@ -156,6 +158,8 @@ $statement = Freshsauce\Model\Model::execute(
 
 $rows = $statement->fetchAll(PDO::FETCH_ASSOC);
 ```
+
+If you change a table schema at runtime and need the model to see the new columns without reconnecting, call `YourModel::refreshTableMetadata()`.
 
 ### Validation hooks
 
@@ -225,6 +229,8 @@ Freshsauce\Model\Model::connectDb(
 ```
 
 SQLite is supported in the library and covered by the automated test suite.
+
+Schema-qualified table names such as `reporting.categories` are supported for PostgreSQL models.
 
 ## Built for real projects
 

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -404,6 +404,16 @@ class Model
     }
 
     /**
+     * Refresh cached table metadata for the current model class.
+     *
+     * @return void
+     */
+    public static function refreshTableMetadata(): void
+    {
+        unset(self::$_tableColumns[static::class]);
+    }
+
+    /**
      * Split a table name into schema and table, defaulting schema to public.
      *
      * @param  string  $tableName
@@ -985,7 +995,7 @@ class Model
      * returns an array of objects of the sub-class which match the conditions
      *
      * @param string $SQLfragment conditions, sorting, grouping and limit to apply (to right of WHERE keywords)
-     * @param array<int, mixed> $params optional params to be escaped and injected into the SQL query (standrd PDO syntax)
+     * @param array<int, mixed> $params optional params to be escaped and injected into the SQL query (standard PDO syntax)
      * @param bool $limitOne if true the first match will be returned
      *
      * @return array|static|null
@@ -999,7 +1009,7 @@ class Model
      * returns an array of objects of the sub-class which match the conditions
      *
      * @param string $SQLfragment conditions, sorting, grouping and limit to apply (to right of WHERE keywords)
-     * @param array  $params      optional params to be escaped and injected into the SQL query (standrd PDO syntax)
+     * @param array  $params      optional params to be escaped and injected into the SQL query (standard PDO syntax)
      *
      * @return array object[] of objects of calling class
      */
@@ -1014,7 +1024,7 @@ class Model
      * returns an object of the sub-class which matches the conditions
      *
      * @param string $SQLfragment conditions, sorting, grouping and limit to apply (to right of WHERE keywords)
-     * @param array  $params      optional params to be escaped and injected into the SQL query (standrd PDO syntax)
+     * @param array  $params      optional params to be escaped and injected into the SQL query (standard PDO syntax)
      *
      * @return static|null object of calling class
      */
@@ -1137,7 +1147,7 @@ class Model
      * Delete records based on an SQL conditions
      *
      * @param string $where  SQL fragment of conditions
-     * @param array  $params optional params to be escaped and injected into the SQL query (standrd PDO syntax)
+     * @param array  $params optional params to be escaped and injected into the SQL query (standard PDO syntax)
      *
      * @return \PDOStatement
      */
@@ -1207,6 +1217,16 @@ class Model
     }
 
     /**
+     * Return a UTC timestamp string suitable for the built-in timestamp columns.
+     *
+     * @return string
+     */
+    protected static function currentTimestamp(): string
+    {
+        return gmdate('Y-m-d H:i:s');
+    }
+
+    /**
      * insert a row into the database table, and update the primary key field with the one generated on insert
      *
      * @param  boolean  $autoTimestamp  true by default will set updated_at & created_at fields if present
@@ -1219,7 +1239,7 @@ class Model
     public function insert(bool $autoTimestamp = true, bool $allowSetPrimaryKey = false): bool
     {
         $pk      = static::$_primary_column_name;
-        $timeStr = gmdate('Y-m-d H:i:s');
+        $timeStr = static::currentTimestamp();
         if ($autoTimestamp && in_array('created_at', static::getFieldnames())) {
             $this->created_at = $timeStr;
         }
@@ -1291,7 +1311,7 @@ class Model
     public function update(bool $autoTimestamp = true): bool
     {
         if ($autoTimestamp && in_array('updated_at', static::getFieldnames())) {
-            $this->updated_at = gmdate('Y-m-d H:i:s');
+            $this->updated_at = static::currentTimestamp();
         }
         $this->runUpdateValidation();
         $set             = $this->setString();
@@ -1305,10 +1325,11 @@ class Model
             $query,
             $set['params']
         );
-        if ($st->rowCount() == 1) {
+        if ($this->updateSucceeded($st)) {
             $this->clearDirtyFields();
+            return true;
         }
-        return ($st->rowCount() == 1);
+        return false;
     }
 
     /**
@@ -1415,6 +1436,25 @@ class Model
         }
 
         return $this->$primaryKey !== null;
+    }
+
+    /**
+     * Determine whether an update succeeded even when the driver reports zero changed rows.
+     *
+     * @param \PDOStatement $statement
+     *
+     * @return bool
+     */
+    protected function updateSucceeded(\PDOStatement $statement): bool
+    {
+        if ($statement->rowCount() > 0) {
+            return true;
+        }
+
+        return static::existsWhere(
+            static::_quote_identifier(static::$_primary_column_name) . ' = ?',
+            [$this->{static::$_primary_column_name}]
+        );
     }
 
     /**

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -1447,13 +1447,25 @@ class Model
      */
     protected function updateSucceeded(\PDOStatement $statement): bool
     {
-        if ($statement->rowCount() > 0) {
+        $count = $statement->rowCount();
+
+        if ($count === 1) {
             return true;
         }
 
-        return static::existsWhere(
-            static::_quote_identifier(static::$_primary_column_name) . ' = ?',
-            [$this->{static::$_primary_column_name}]
+        if ($count === 0) {
+            return static::existsWhere(
+                static::_quote_identifier(static::$_primary_column_name) . ' = ?',
+                [$this->{static::$_primary_column_name}]
+            );
+        }
+
+        throw new ModelException(
+            sprintf(
+                'Update affected %d rows for %s; expected at most one row.',
+                $count,
+                static::class
+            )
         );
     }
 

--- a/test-src/Model/CodedCategory.php
+++ b/test-src/Model/CodedCategory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+/**
+ * @property int|null $code
+ * @property string|null $name
+ */
+class CodedCategory extends \Freshsauce\Model\Model
+{
+    protected static $_primary_column_name = 'code';
+
+    protected static $_tableName = 'coded_categories';
+}

--- a/test-src/Model/MetadataRefreshCategory.php
+++ b/test-src/Model/MetadataRefreshCategory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+/**
+ * @property int|null $id
+ * @property string|null $name
+ * @property string|null $description
+ */
+class MetadataRefreshCategory extends \Freshsauce\Model\Model
+{
+    protected static $_tableName = 'metadata_refresh_categories';
+}

--- a/test-src/Model/SchemaQualifiedCategory.php
+++ b/test-src/Model/SchemaQualifiedCategory.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+/**
+ * @property int|null $id
+ * @property string|null $name
+ */
+class SchemaQualifiedCategory extends \Freshsauce\Model\Model
+{
+    protected static $_tableName = 'orm_phase3.schema_categories';
+}

--- a/test-src/Model/UntimedCategory.php
+++ b/test-src/Model/UntimedCategory.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+/**
+ * @property int|null $id
+ * @property string|null $name
+ */
+class UntimedCategory extends \Freshsauce\Model\Model
+{
+    protected static $_tableName = 'untimed_categories';
+}

--- a/tests/Model/CategoryTest.php
+++ b/tests/Model/CategoryTest.php
@@ -75,14 +75,17 @@ class CategoryTest extends TestCase
                  "updated_at" TIMESTAMP NULL,
                  "created_at" TIMESTAMP NULL
                )',
+                'DROP TABLE IF EXISTS "coded_categories"',
                 'CREATE TABLE "coded_categories" (
                  "code" INTEGER PRIMARY KEY,
                  "name" VARCHAR(120) NULL
                )',
+                'DROP TABLE IF EXISTS "metadata_refresh_categories"',
                 'CREATE TABLE "metadata_refresh_categories" (
                  "id" SERIAL PRIMARY KEY,
                  "name" VARCHAR(120) NULL
                )',
+                'DROP TABLE IF EXISTS "untimed_categories"',
                 'CREATE TABLE "untimed_categories" (
                  "id" SERIAL PRIMARY KEY,
                  "name" VARCHAR(120) NULL

--- a/tests/Model/CategoryTest.php
+++ b/tests/Model/CategoryTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 class CategoryTest extends TestCase
 {
     private const TEST_DB_NAME = 'categorytest';
+    private const PGSQL_SCHEMA = 'orm_phase3';
     private const SQLITE_SEQUENCE_TABLE = 'sqlite_sequence';
     private static ?string $driverName = null;
 
@@ -48,15 +49,48 @@ class CategoryTest extends TestCase
                  `created_at` TIMESTAMP NULL DEFAULT NULL,
                  PRIMARY KEY (`id`)
                ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8',
+                'CREATE TABLE `coded_categories` (
+                 `code` INT(11) UNSIGNED NOT NULL,
+                 `name` VARCHAR(120) DEFAULT NULL,
+                 PRIMARY KEY (`code`)
+               ) ENGINE=InnoDB DEFAULT CHARSET=utf8',
+                'CREATE TABLE `metadata_refresh_categories` (
+                 `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+                 `name` VARCHAR(120) DEFAULT NULL,
+                 PRIMARY KEY (`id`)
+               ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8',
+                'CREATE TABLE `untimed_categories` (
+                 `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+                 `name` VARCHAR(120) DEFAULT NULL,
+                 PRIMARY KEY (`id`)
+               ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8',
             ];
         } elseif (self::$driverName === 'pgsql') {
             $sql_setup = [
+                'DROP SCHEMA IF EXISTS "' . self::PGSQL_SCHEMA . '" CASCADE',
                 'DROP TABLE IF EXISTS "categories"',
                 'CREATE TABLE "categories" (
                  "id" SERIAL PRIMARY KEY,
                  "name" VARCHAR(120) NULL,
                  "updated_at" TIMESTAMP NULL,
                  "created_at" TIMESTAMP NULL
+               )',
+                'CREATE TABLE "coded_categories" (
+                 "code" INTEGER PRIMARY KEY,
+                 "name" VARCHAR(120) NULL
+               )',
+                'CREATE TABLE "metadata_refresh_categories" (
+                 "id" SERIAL PRIMARY KEY,
+                 "name" VARCHAR(120) NULL
+               )',
+                'CREATE TABLE "untimed_categories" (
+                 "id" SERIAL PRIMARY KEY,
+                 "name" VARCHAR(120) NULL
+               )',
+                'CREATE SCHEMA "' . self::PGSQL_SCHEMA . '"',
+                'CREATE TABLE "' . self::PGSQL_SCHEMA . '"."schema_categories" (
+                 "id" SERIAL PRIMARY KEY,
+                 "name" VARCHAR(120) NULL
                )',
             ];
         } elseif (self::$driverName === 'sqlite') {
@@ -67,6 +101,21 @@ class CategoryTest extends TestCase
                  `name` VARCHAR(120) NULL,
                  `updated_at` TEXT NULL,
                  `created_at` TEXT NULL
+               )',
+                'DROP TABLE IF EXISTS `coded_categories`',
+                'CREATE TABLE `coded_categories` (
+                 `code` INTEGER PRIMARY KEY,
+                 `name` VARCHAR(120) NULL
+               )',
+                'DROP TABLE IF EXISTS `metadata_refresh_categories`',
+                'CREATE TABLE `metadata_refresh_categories` (
+                 `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+                 `name` VARCHAR(120) NULL
+               )',
+                'DROP TABLE IF EXISTS `untimed_categories`',
+                'CREATE TABLE `untimed_categories` (
+                 `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+                 `name` VARCHAR(120) NULL
                )',
             ];
         } else {
@@ -87,7 +136,11 @@ class CategoryTest extends TestCase
         if (self::$driverName === 'mysql') {
             Freshsauce\Model\Model::execute('DROP DATABASE IF EXISTS `' . self::TEST_DB_NAME . '`');
         } elseif (self::$driverName === 'pgsql') {
+            Freshsauce\Model\Model::execute('DROP SCHEMA IF EXISTS "' . self::PGSQL_SCHEMA . '" CASCADE');
             Freshsauce\Model\Model::execute('DROP TABLE IF EXISTS "categories"');
+            Freshsauce\Model\Model::execute('DROP TABLE IF EXISTS "coded_categories"');
+            Freshsauce\Model\Model::execute('DROP TABLE IF EXISTS "metadata_refresh_categories"');
+            Freshsauce\Model\Model::execute('DROP TABLE IF EXISTS "untimed_categories"');
         }
     }
 
@@ -99,10 +152,20 @@ class CategoryTest extends TestCase
 
         if (self::$driverName === 'mysql') {
             Freshsauce\Model\Model::execute('TRUNCATE TABLE `categories`');
+            Freshsauce\Model\Model::execute('TRUNCATE TABLE `coded_categories`');
+            Freshsauce\Model\Model::execute('TRUNCATE TABLE `metadata_refresh_categories`');
+            Freshsauce\Model\Model::execute('TRUNCATE TABLE `untimed_categories`');
         } elseif (self::$driverName === 'pgsql') {
             Freshsauce\Model\Model::execute('TRUNCATE TABLE "categories" RESTART IDENTITY');
+            Freshsauce\Model\Model::execute('TRUNCATE TABLE "coded_categories"');
+            Freshsauce\Model\Model::execute('TRUNCATE TABLE "metadata_refresh_categories" RESTART IDENTITY');
+            Freshsauce\Model\Model::execute('TRUNCATE TABLE "untimed_categories" RESTART IDENTITY');
+            Freshsauce\Model\Model::execute('TRUNCATE TABLE "' . self::PGSQL_SCHEMA . '"."schema_categories" RESTART IDENTITY');
         } elseif (self::$driverName === 'sqlite') {
             Freshsauce\Model\Model::execute('DELETE FROM `categories`');
+            Freshsauce\Model\Model::execute('DELETE FROM `coded_categories`');
+            Freshsauce\Model\Model::execute('DELETE FROM `metadata_refresh_categories`');
+            Freshsauce\Model\Model::execute('DELETE FROM `untimed_categories`');
             $this->resetSqliteSequenceIfPresent();
         }
     }
@@ -110,10 +173,12 @@ class CategoryTest extends TestCase
     private function resetSqliteSequenceIfPresent(): void
     {
         try {
-            Freshsauce\Model\Model::execute(
-                'DELETE FROM `' . self::SQLITE_SEQUENCE_TABLE . '` WHERE `name` = ?',
-                ['categories']
-            );
+            foreach (['categories', 'metadata_refresh_categories', 'untimed_categories'] as $tableName) {
+                Freshsauce\Model\Model::execute(
+                    'DELETE FROM `' . self::SQLITE_SEQUENCE_TABLE . '` WHERE `name` = ?',
+                    [$tableName]
+                );
+            }
         } catch (\PDOException $e) {
             if (strpos($e->getMessage(), 'no such table: ' . self::SQLITE_SEQUENCE_TABLE) === false) {
                 throw $e;
@@ -318,6 +383,126 @@ class CategoryTest extends TestCase
         $statement = App\Model\Category::deleteAllWhere('name = ?', ['Alpha']);
         $this->assertSame(1, $statement->rowCount());
         $this->assertSame(0, App\Model\Category::count());
+    }
+
+    public function testModelSubclassesCanShareTheInheritedConnection(): void
+    {
+        $category = $this->createCategory('Shared connection');
+
+        $reloaded = App\Model\LegacyValidatingCategory::getById((int) $category->id);
+
+        $this->assertNotNull($reloaded);
+        $this->assertInstanceOf(App\Model\LegacyValidatingCategory::class, $reloaded);
+        $this->assertSame('Shared connection', $reloaded->name);
+    }
+
+    public function testCustomPrimaryKeyLifecycleWorksAcrossDrivers(): void
+    {
+        $category = new App\Model\CodedCategory([
+            'code' => 42,
+            'name' => 'Meaning',
+        ]);
+
+        $this->assertTrue($category->insert(false, true));
+        $this->assertSame(42, (int) $category->code);
+
+        $reloaded = App\Model\CodedCategory::getById(42);
+        $this->assertNotNull($reloaded);
+        $this->assertSame('Meaning', $reloaded->name);
+
+        $reloaded->name = 'Updated meaning';
+        $this->assertTrue($reloaded->save());
+        $this->assertSame('Updated meaning', App\Model\CodedCategory::getById(42)?->name);
+    }
+
+    public function testMetadataRefreshAllowsNewColumnsWithoutReconnect(): void
+    {
+        $withoutRefresh = new App\Model\MetadataRefreshCategory([
+            'name' => 'Before refresh',
+            'description' => 'ignored until refresh',
+        ]);
+        $this->assertFalse(isset($withoutRefresh->description));
+
+        if (self::$driverName === 'mysql') {
+            Freshsauce\Model\Model::execute(
+                'ALTER TABLE `metadata_refresh_categories` ADD COLUMN `description` VARCHAR(120) NULL'
+            );
+        } elseif (self::$driverName === 'pgsql') {
+            Freshsauce\Model\Model::execute(
+                'ALTER TABLE "metadata_refresh_categories" ADD COLUMN "description" VARCHAR(120) NULL'
+            );
+        } elseif (self::$driverName === 'sqlite') {
+            Freshsauce\Model\Model::execute(
+                'ALTER TABLE `metadata_refresh_categories` ADD COLUMN `description` VARCHAR(120) NULL'
+            );
+        }
+
+        App\Model\MetadataRefreshCategory::refreshTableMetadata();
+
+        $withRefresh = new App\Model\MetadataRefreshCategory([
+            'name' => 'After refresh',
+            'description' => 'captured after refresh',
+        ]);
+        $this->assertSame('captured after refresh', $withRefresh->description);
+        $this->assertTrue($withRefresh->save());
+        $this->assertSame('captured after refresh', App\Model\MetadataRefreshCategory::getById((int) $withRefresh->id)?->description);
+    }
+
+    public function testSchemaQualifiedPostgresTablesWork(): void
+    {
+        if (self::$driverName !== 'pgsql') {
+            $this->markTestSkipped('Schema-qualified table coverage is PostgreSQL-specific.');
+        }
+
+        $category = new App\Model\SchemaQualifiedCategory([
+            'name' => 'Namespaced category',
+        ]);
+
+        $this->assertTrue($category->save());
+        $reloaded = App\Model\SchemaQualifiedCategory::getById((int) $category->id);
+
+        $this->assertNotNull($reloaded);
+        $this->assertSame('Namespaced category', $reloaded->name);
+    }
+
+    public function testInsertAndUpdateCanOptOutOfAutomaticTimestamps(): void
+    {
+        $category = new App\Model\Category([
+            'name' => 'No automatic timestamps',
+        ]);
+
+        $this->assertTrue($category->insert(false));
+        $this->assertNull($category->created_at);
+        $this->assertNull($category->updated_at);
+
+        $category->name = 'Still no automatic timestamps';
+        $this->assertTrue($category->update(false));
+        $this->assertNull($category->updated_at);
+
+        $reloaded = App\Model\Category::getById((int) $category->id);
+        $this->assertNotNull($reloaded);
+        $this->assertNull($reloaded->created_at);
+        $this->assertNull($reloaded->updated_at);
+    }
+
+    public function testModelsWithoutTimestampColumnsSaveNormally(): void
+    {
+        $category = new App\Model\UntimedCategory([
+            'name' => 'Untimed',
+        ]);
+
+        $this->assertTrue($category->save());
+        $this->assertNotNull($category->id);
+        $this->assertSame('Untimed', App\Model\UntimedCategory::getById((int) $category->id)?->name);
+    }
+
+    public function testUpdateTreatsExistingRowAsSuccessWhenDriverReportsZeroChangedRows(): void
+    {
+        $category = $this->createCategory('No-op update');
+        $category->name = 'No-op update';
+
+        $this->assertTrue($category->update(false));
+        $this->assertFalse($category->isFieldDirty('name'));
     }
 
     public function testFocusedQueryHelpers(): void


### PR DESCRIPTION
## Summary
Implements Phase 3 of the roadmap around quality, portability, and maintenance for the ORM core.

This change tightens behavior that was already mostly present in the library but not consistently expressed across drivers. In practice, it makes metadata refresh explicit, normalizes no-op update handling, and broadens integration coverage for cases that were under-tested.

## User impact
Consumers can now refresh cached table metadata without reconnecting by calling `YourModel::refreshTableMetadata()`. That matters when schemas change during long-lived processes or test runs.

Update behavior is also less sensitive to driver-specific `rowCount()` semantics. A no-op update on an existing row is now treated as a successful update instead of looking like a failure simply because the database reported zero changed rows.

The documentation now makes UTC timestamp behavior explicit and calls out support for PostgreSQL schema-qualified tables.

## Root cause
A few driver-facing behaviors depended on incidental implementation details rather than explicit library rules.

Table metadata was cached per model class with no direct way to invalidate it short of reconnecting. Update success also relied too directly on raw PDO affected-row behavior, which varies across drivers for no-op writes. Several edge cases were effectively supported but not protected by integration coverage.

## Fix
The model now exposes `refreshTableMetadata()` to clear cached column metadata for the current model class. Timestamp generation was centralized through `currentTimestamp()` so the UTC formatting behavior is explicit.

The update path now uses an `updateSucceeded()` check that treats an update as successful when the target row still exists, even if the driver reports zero changed rows. That keeps behavior consistent for no-op updates without loosening failure handling for missing rows.

The test suite was expanded with cross-driver coverage for inherited connections, custom primary keys, schema refresh behavior, timestamp opt-out behavior, timestamp-less tables, PostgreSQL schema-qualified tables, and no-op update handling.

## Validation
- `vendor/bin/phpunit -c phpunit.xml.dist`
- `vendor/bin/phpstan analyse -c phpstan.neon`
- `vendor/bin/php-cs-fixer fix --dry-run --diff`
